### PR TITLE
Correct color order of Robot 36 mode.

### DIFF
--- a/pysstv/color.py
+++ b/pysstv/color.py
@@ -90,7 +90,7 @@ class Robot36(ColorSSTV):
     INTER_CH_FREQS = [None, FREQ_BLACK, FREQ_WHITE]
 
     def on_init(self):
-        self.yuv = self.image.convert('YCbCr').load()
+        self.yuv = self.image.convert('YCrCb').load()
 
     def encode_line(self, line):
         pixels = [self.yuv[col, line] for col in range(self.WIDTH)]


### PR DESCRIPTION
The color sequence for Robot 36 is listed as YCrCb in the SSTV Handbook: http://www.sstv-handbook.com/download/sstv_04.pdf (Table 4.3) and the Dayton Paper: https://web.archive.org/web/20120104184535/http://www.barberdsp.com/files/Dayton%20Paper.pdf