### PR TITLE
Bugfix for python>=3.9.1

### DIFF
--- a/pysstv/sstv.py
+++ b/pysstv/sstv.py
@@ -54,7 +54,7 @@ class SSTV(object):
             wav.setnchannels(self.nchannels)
             wav.setsampwidth(self.bits // 8)
             wav.setframerate(self.samples_per_sec)
-            wav.writeframes(data.tostring())
+            wav.writeframes(data)
 
     def gen_samples(self):
         """generates discrete samples from gen_values()


### PR DESCRIPTION
Removed tostring() in write_wav.  Python 3.9+ has removed the tostring() methods from array.array and other primitives.