### PR TITLE
Add entry_point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,11 @@ setup(
     author_email='vsza@vsza.hu',
     url='https://github.com/dnet/pySSTV',
     packages=['pysstv', 'pysstv.tests', 'pysstv.examples'],
+    entry_points={
+        'console_scripts': [
+            'pysstv = pysstv.__main__:main',
+        ],
+    },
     keywords='HAM SSTV slow-scan television Scottie Martin Robot Pasokon',
     install_requires = ['Pillow', 'six'],
     license='MIT',


### PR DESCRIPTION
Add a console_script named ``pysstv``.

This allows pysstv to be run with the command ``pysstv`` as an alternative to running ``python -m pysstv``