### PR TITLE
color: Drop width for Scottie S2 mode

### DIFF
--- a/pysstv/color.py
+++ b/pysstv/color.py
@@ -74,7 +74,6 @@ class ScottieS1(MartinM1):
 class ScottieS2(ScottieS1):
     VIS_CODE = 0x38
     SCAN = 88.064 - ScottieS1.INTER_CH_GAP
-    WIDTH = 160
 
 
 class ScottieDX(ScottieS1):


### PR DESCRIPTION
It's the same width as the other Scottie modes according to the Dayton paper presented by JL Barber (N7CXI).

Fixes issue #38 