### PR TITLE
grayscale: Reduce the scan line a little for BW8

### DIFF
--- a/pysstv/grayscale.py
+++ b/pysstv/grayscale.py
@@ -27,7 +27,7 @@ class Robot8BW(GrayscaleSSTV):
     WIDTH = 160
     HEIGHT = 120
     SYNC = 7
-    SCAN = 60
+    SCAN = 59.90
 
 
 class Robot24BW(GrayscaleSSTV):


### PR DESCRIPTION
Testing with QSSTV with slant-correction disabled, we achieve a more reliable decode if we turn the scan line duration down a wee bit.

The original image (created in Inkscape):
![sstv-test-bw](https://github.com/user-attachments/assets/57f04ae7-73f1-4898-8a08-01d05242d061)

Before modifications:
![BW8_20240727_044438](https://github.com/user-attachments/assets/bac5332c-2ae6-4866-bbfd-599d7ebd2ce2)

After:
![BW8_20240727_044845](https://github.com/user-attachments/assets/def6c4c0-8b4b-4751-bc68-a171ef934636)